### PR TITLE
Major error fixes + 3dplots

### DIFF
--- a/doc/examples.py
+++ b/doc/examples.py
@@ -128,9 +128,9 @@ plt.show()
 
 # ---------------------- generation 3d plots
 
+# definition of incidence-angles
 thetaplot = 55.
 phiplot = 0.
-
 
 
 
@@ -139,7 +139,7 @@ theta,phi = np.linspace(np.deg2rad(1.),np.deg2rad(89.),25),np.linspace(0.,np.pi,
 THETA,PHI = np.meshgrid(theta,phi)
 
 
-# calculate bistatic coefficients
+# calculate bistatic fn coefficients
 print('start of bistatic coefficient generation')
 testfn = RT1(1., np.cos(np.deg2rad(thetaplot)), np.cos(np.deg2rad(45)), phiplot, np.pi, RV=V, SRF=SRF, fn=None, geometry='fvfv').fn
 
@@ -152,8 +152,6 @@ int3d=[[0 for i in range(0,len(theta))] for j in range(0,len(phi))]
 
 # definition of function to evaluate bistatic contributions
 # since this step might take a while an estimation of the calculation-time was included
-
-# define incidence angle for plotting
 
 def Rad(tt,pp):
     for i in range(0,len(tt)):
@@ -182,19 +180,13 @@ def sphericaltransform(r):
     return X,Y,Z
 
 
+
+# plot of 3d scattering distribution
 import mpl_toolkits.mplot3d as plt3d
-
-
-
 
 fig = plt.figure(figsize=plt.figaspect(1.))
 ax3d = fig.add_subplot(1,1,1,projection='3d')
 
-
-
-
-
-#cmap=plt.get_cmap('Reds_r')
 
 plot = ax3d.plot_surface(
     sphericaltransform(tot3dplot)[0],sphericaltransform(tot3dplot)[1],sphericaltransform(tot3dplot)[2] ,rstride=1, cstride=1, color='Gray',
@@ -224,18 +216,10 @@ ax3d.set_zticks([])
 
 
 
-#Xb = np.array([0.,0.,0.,0.,1.,1.,1.,1.])*np.max(sphericaltransform(tot3dplot)) + np.array([1.,1.,1.,1.,0.,0.,0.,0.])*np.min(sphericaltransform(tot3dplot))
-#Yb = np.array([0.,0.,1.,1.,0.,0.,1.,1.])*(np.max(sphericaltransform(tot3dplot)) + np.abs(np.min(sphericaltransform(tot3dplot))))
-##Zb = np.array([0.,0.,0.,0.,1.,1.,1.,1.])*np.max(sphericaltransform(tot3dplot)) + np.array([1.,1.,1.,1.,0.,0.,0.,0.])*np.min(sphericaltransform(tot3dplot))
-#
-#Zb = np.array([0.,1.,0.,1.,0.,1.,0.,1.])*(np.max(sphericaltransform(tot3dplot)) + np.abs(np.min(sphericaltransform(tot3dplot))))
-#for xb, yb, zb in zip(Xb, Yb, Zb):
-#   ax3d.plot([xb], [yb], [zb], 'wo')
-
-plt.show()
-
 # ensure display of correct aspect ratio (bug in mplot3d)
 # due to the bug it is only possible to have equally sized axes (without changing the mplotlib code itself)
 ax3d.auto_scale_xyz([np.min(sphericaltransform(tot3dplot)),np.max(sphericaltransform(tot3dplot))],
                     [0.,np.max(sphericaltransform(tot3dplot))+np.abs(np.min(sphericaltransform(tot3dplot)))],
                       [0.,np.max(sphericaltransform(tot3dplot))+np.abs(np.min(sphericaltransform(tot3dplot)))])
+
+plt.show()

--- a/doc/examples.py
+++ b/doc/examples.py
@@ -128,6 +128,12 @@ plt.show()
 
 # ---------------------- generation 3d plots
 
+thetaplot = 55.
+phiplot = 0.
+
+
+
+
 # define plot-grid
 theta,phi = np.linspace(np.deg2rad(1.),np.deg2rad(89.),25),np.linspace(0.,np.pi,25)
 THETA,PHI = np.meshgrid(theta,phi)
@@ -135,7 +141,7 @@ THETA,PHI = np.meshgrid(theta,phi)
 
 # calculate bistatic coefficients
 print('start of bistatic coefficient generation')
-testfn = RT1(1., np.cos(np.deg2rad(45)), np.cos(np.deg2rad(45)), 0., np.pi, RV=V, SRF=SRF, fn=None, geometry='fvfv').fn
+testfn = RT1(1., np.cos(np.deg2rad(thetaplot)), np.cos(np.deg2rad(45)), phiplot, np.pi, RV=V, SRF=SRF, fn=None, geometry='fvfv').fn
 
 # initialize arrays
 tot3d=[[0 for i in range(0,len(theta))] for j in range(0,len(phi))]
@@ -147,12 +153,14 @@ int3d=[[0 for i in range(0,len(theta))] for j in range(0,len(phi))]
 # definition of function to evaluate bistatic contributions
 # since this step might take a while an estimation of the calculation-time was included
 
+# define incidence angle for plotting
+
 def Rad(tt,pp):
     for i in range(0,len(tt)):
         if i == 0: tic = timeit.default_timer()
         if i == 0: print('... estimating evaluation-time...')
         for j in range(0,len(pp)):
-            test = RT1(1., np.cos(np.deg2rad(45)), np.cos(theta[i]), 0.,phi[j], RV=V, SRF=SRF, fn=testfn, geometry='ffff')
+            test = RT1(1., np.cos(np.deg2rad(thetaplot)), np.cos(theta[i]), phiplot,phi[j], RV=V, SRF=SRF, fn=testfn, geometry='ffff')
             tot3d[j][i],surf3d[j][i],vol3d[j][i],int3d[j][i] = test.calc()
         if i == 0: toc = timeit.default_timer()
         if i == 0: print('evaluation of 3dplot will take approximately ' + str(round((toc-tic)*len(tt)/60.,2)) + ' minutes')
@@ -182,9 +190,9 @@ import mpl_toolkits.mplot3d as plt3d
 fig = plt.figure(figsize=plt.figaspect(1.))
 ax3d = fig.add_subplot(1,1,1,projection='3d')
 
-ax3d.set_xlim3d(np.min(sphericaltransform(tot3dplot)[0])*1.5,np.max(sphericaltransform(tot3dplot)[0]))
-ax3d.set_ylim3d(np.min(sphericaltransform(tot3dplot)[0])*1.5,np.max(sphericaltransform(tot3dplot)[0]))
-ax3d.set_zlim3d(np.min(sphericaltransform(tot3dplot)[2]),np.max(sphericaltransform(tot3dplot)[2]))
+
+
+
 
 #cmap=plt.get_cmap('Reds_r')
 
@@ -215,21 +223,19 @@ ax3d.set_yticks([])
 ax3d.set_zticks([])
 
 
-    
+
+#Xb = np.array([0.,0.,0.,0.,1.,1.,1.,1.])*np.max(sphericaltransform(tot3dplot)) + np.array([1.,1.,1.,1.,0.,0.,0.,0.])*np.min(sphericaltransform(tot3dplot))
+#Yb = np.array([0.,0.,1.,1.,0.,0.,1.,1.])*(np.max(sphericaltransform(tot3dplot)) + np.abs(np.min(sphericaltransform(tot3dplot))))
+##Zb = np.array([0.,0.,0.,0.,1.,1.,1.,1.])*np.max(sphericaltransform(tot3dplot)) + np.array([1.,1.,1.,1.,0.,0.,0.,0.])*np.min(sphericaltransform(tot3dplot))
+#
+#Zb = np.array([0.,1.,0.,1.,0.,1.,0.,1.])*(np.max(sphericaltransform(tot3dplot)) + np.abs(np.min(sphericaltransform(tot3dplot))))
+#for xb, yb, zb in zip(Xb, Yb, Zb):
+#   ax3d.plot([xb], [yb], [zb], 'wo')
+
 plt.show()
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+# ensure display of correct aspect ratio (bug in mplot3d)
+# due to the bug it is only possible to have equally sized axes (without changing the mplotlib code itself)
+ax3d.auto_scale_xyz([np.min(sphericaltransform(tot3dplot)),np.max(sphericaltransform(tot3dplot))],
+                    [0.,np.max(sphericaltransform(tot3dplot))+np.abs(np.min(sphericaltransform(tot3dplot)))],
+                      [0.,np.max(sphericaltransform(tot3dplot))+np.abs(np.min(sphericaltransform(tot3dplot)))])

--- a/rt1/volume.py
+++ b/rt1/volume.py
@@ -46,15 +46,75 @@ class Volume(Scatter):
         # replace arguments and evaluate expression
         return self._func.xreplace({theta_i:t0, theta_s:ts, phi_i:p0, phi_s:ps}).evalf()
 
-    def legexpansion(self):
-        theta_i = sp.Symbol('theta_i')
+    def legexpansion(self,t_i,t_ex,p_0,p_ex,geometry):
+        assert self.ncoefs > 0
+
+        """
+        Definition of the legendre-expansion of the volume-phase-function.        
+        
+        The geometry-parameter consists of 4 characters that define the 
+        geometry of the experiment-setup:
+        
+        The 4 characters represent in order: theta_i, theta_ex, phi_i, phi_ex
+        
+        'f' indicates that the angle is treated 'fixed' 
+        'v' indicates that the angle is treated 'variable'
+        
+        Passing  geometry = 'mono'  indicates a monstatic geometry
+        (i.e.:  theta_i = theta_ex, phi_ex = phi_i + pi)
+        """
+
+                        
         theta_s = sp.Symbol('theta_s')
-        phi_i = sp.Symbol('phi_i')
         phi_s = sp.Symbol('phi_s')
+
 
         NP = self.ncoefs
         n = sp.Symbol('n')
+                
+
+        # define sympy variables based on chosen geometry
+        if geometry == 'mono':
+            theta_i = sp.Symbol('theta_i')
+            theta_ex = theta_i
+            phi_i = p_0
+        else:
+            if geometry[0] == 'v':
+                theta_i = sp.Symbol('theta_i')
+            elif geometry[0] == 'f':
+                theta_i = t_i
+            else:
+                raise AssertionError('wrong choice of theta_i geometry')
+                
+            if geometry[1] == 'v':
+                theta_ex = sp.Symbol('theta_ex')
+            elif geometry[1] == 'f':
+                theta_ex = t_ex
+            else:
+                raise AssertionError('wrong choice of theta_ex geometry')
+                
+            if geometry[2] == 'v':
+                phi_i = sp.Symbol('phi_i')
+            elif geometry[2] == 'f':
+                phi_i = p_0
+            else:
+                raise AssertionError('wrong choice of phi_i geometry')
+    
+            if geometry[3] == 'v':
+                phi_ex = sp.Symbol('phi_ex')
+            elif geometry[3] == 'f':
+                phi_ex = p_ex
+            else:
+                raise AssertionError('wrong choice of phi_ex geometry')
+
+ 
+
+        #correct for backscattering
         return sp.Sum(self.legcoefs*sp.legendre(n,self.thetap(theta_i,theta_s,phi_i,phi_s)),(n,0,NP))  #.doit()  # this generates a code still that is not yet evaluated; doit() will result in GMMA error due to potential negative numbers
+
+
+
+
 
 
 class Rayleigh(Volume):
@@ -81,7 +141,7 @@ class Rayleigh(Volume):
         set Legrende coefficients
         needs to be a function that can be later evaluated by subsituting 'n'
         """
-        self.ncoefs = 10
+        self.ncoefs = 2    #only 2 coefficients are needed to correctly represent the Rayleigh scattering function
         n = sp.Symbol('n')
         self.legcoefs = ((3./(16.*sp.pi))*((4./3.)*sp.KroneckerDelta(0,n)+(2./3.)*sp.KroneckerDelta(2,n))).expand()
 


### PR DESCRIPTION
- fixed errors in definition of legendre-expansion and in the  'phi_s' - integration-routine.
  -> code is now capable of correctly generating the plots presented in the paper!
- added example on how to plot bistatic scattering distributions as shown in the paper.
  -> 3d-plots still not perfect since mplot3d has two bugs that are problematic:
  - aspect-ratio of generated plots can not be set correctly
      -> problem bypassed by setting all axes-ranges equal
  - plotting multiple surfaces within a single plot results in strange plot-artefacts
    since mplot3d can not resolve which surface is in front of the other.
      -> problem bypassed by setting transparency of surfaces to 0.5
