### PR TITLE
Linear combination

### DIFF
--- a/doc/examples/examples.py
+++ b/doc/examples/examples.py
@@ -55,10 +55,10 @@ else:
 
 
 # list of volume-scattering phase-functions to be combined
-phasechoices = [HenyeyGreenstein(tau = 0.5, omega = 0.4, t=  0.5, ncoefs = 10, a=[-1.,1.,1.]),  # forward-scattering-peak
-                HenyeyGreenstein(tau = 0.5, omega = 0.4, t= -0.2, ncoefs = 10, a=[-1.,1.,1.]),  # backscattering-peak
-                HenyeyGreenstein(tau = 0.5, omega = 0.4, t= -0.5, ncoefs = 10, a=[ 1.,1.,1.]),  # downward-specular peak
-                HenyeyGreenstein(tau = 0.5, omega = 0.4, t=  0.2, ncoefs = 10, a=[ 1.,1.,1.]),  # upward-specular peak
+phasechoices = [HenyeyGreenstein(t=  0.5, ncoefs = 10, a=[-1.,1.,1.]),  # forward-scattering-peak
+                HenyeyGreenstein(t= -0.2, ncoefs = 10, a=[-1.,1.,1.]),  # backscattering-peak
+                HenyeyGreenstein(t= -0.5, ncoefs = 10, a=[ 1.,1.,1.]),  # downward-specular peak
+                HenyeyGreenstein(t=  0.2, ncoefs = 10, a=[ 1.,1.,1.]),  # upward-specular peak
                ]
 # weighting-factors for the individual phase-functions
 Vweights = [.3,.3,.2,.2]
@@ -78,14 +78,13 @@ V = map(list,zip(Vweights, phasechoices))
 SRF = map(list,zip(BRDFweights, BRDFchoices))
 
 
-#   extract the combined surface- and volume- class elements and plot them
-#combinedV = RT1(1., 0., 0., 0., 0., RV=V, SRF=SRF, fn=None, geometry='mono').RV
-#combinedSRF = RT1(1., 0., 0., 0., 0., RV=V, SRF=SRF, fn=None, geometry='mono').SRF
 
 #hg = Plots().polarplot(V=combinedV, SRF = combinedSRF, pmultip = 1., incp = [15,45,85], plabel = 'Henyey Greenstein Phase Function', paprox = True, BRDFaprox=True)
 
 
 
+from rt1.volume import LinCombV
+V = LinCombV(tau=0.5, omega=0.4, Vchoices=V)
 
 # initialize output fields for faster processing
 Itot = np.ones_like(inc)*np.nan
@@ -160,7 +159,7 @@ plot1 = Plots().polarplot(R,incp = list(np.linspace(0,120,5)), incBRDF = list(np
 
 # ---------------- GENERATION OF BACKSCATTER PLOTS ----------------
 #       plot backscattered intensity and fractional contributions
-plot2 = Plots().logmono(inc, Itot = Itot, Isurf = Isurf, Ivol = Ivol, Iint = Iint, sig0=True, ylim=[-20,0])
+plot2 = Plots().logmono(inc, Itot = Itot, Isurf = Isurf, Ivol = Ivol, Iint = Iint, sig0=True, ylim=[-20,0], noint=True)
 
 #       plot only backscattering coefficient without fractions
 #Plots().logmono(inc, Itot = Itot, Isurf = Isurf, Ivol = Ivol, Iint = Iint, sig0=True, fractions = False)

--- a/doc/examples/examples.py
+++ b/doc/examples/examples.py
@@ -84,7 +84,12 @@ SRF = map(list,zip(BRDFweights, BRDFchoices))
 
 
 from rt1.volume import LinCombV
+from rt1.surface import LinCombSRF
+
+
 V = LinCombV(tau=0.5, omega=0.4, Vchoices=V)
+
+SRF = LinCombSRF(SRFchoices=SRF)
 
 # initialize output fields for faster processing
 Itot = np.ones_like(inc)*np.nan

--- a/rt1/rt1.py
+++ b/rt1/rt1.py
@@ -53,8 +53,7 @@ class RT1(object):
         I0 : float
             incidence radiation
         RV : Volume
-            random volume object or array of weighting-factors (w_i) and volume-objects (RV_i)
-            shaped in the form  RV = [ [w_1, RV_1], [w_2, RV_2], ...]    with   sum(w_i) = 1
+            random volume object
         SRF: Surface
             random surface object or array of weighting-factors (w_i) and surface-objects (SRF_i)
             shaped in the form  SRF = [ [w_1, SRF_1], [w_2, SRF_2], ...]
@@ -82,15 +81,11 @@ class RT1(object):
 
 
         assert RV is not None, 'ERROR: needs to provide volume information'
+        self.RV = RV
 
         # the asserts for omega & tau are performed inside the RT1-class rather than the Volume-class
         # to allow calling Volume-elements without providing omega & tau which is needed to generate
         # linear-combinations of Volume-elements with unambiguous tau- & omega-specifications
-        # if an array is provided for RV, call Vcombiner function to generate a combined phase-function element
-        if isinstance(RV,(list,np.ndarray)):
-            self.RV = self._Vcombiner(RV)
-        else:
-            self.RV = RV
 
         assert self.RV.omega is not None, 'Single scattering albedo needs to be provided'
         assert self.RV.tau is not None, 'Optical depth needs to be provided'
@@ -343,72 +338,6 @@ class RT1(object):
 
 
 
-
-    def _Vcombiner(self, Vchoices):
-        '''
-        Returns a Volume-class element based on an input-array of Volume-class elements.
-        The array must be shaped in the form:
-            Vchoices = [  [ weighting-factor   ,   Volume-class element ]  ,  [ weighting-factor   ,   Volume-class element ]  , .....]
-
-        In order to keep the normalization of the phase-functions correct,
-        the sum of the weighting factors must equate to 1!
-
-
-        ATTENTION: the .legexpansion()-function of the combined volume-class element is no longer related to its legcoefs (which are set to 0.)
-                   since the individual legexpansions of the combined volume-class elements are possibly evaluated with a different a-parameter
-                   of the generalized scattering angle! This does not affect any calculations, since the evaluation is exclusively based on the
-                   use of the .legexpansion()-function.
-
-
-
-        '''
-        from volume import Phasefunction
-
-        # test if the weighting-factors equate to 1.
-        np.testing.assert_almost_equal(desired = 1.,actual = np.sum([V[0] for V in Vchoices]), verbose = False, err_msg='The sum of the phase-function weighting-factors must equate to 1 !'),
-
-        # find phase functions with equal a parameters
-        equals = [np.where((np.array([VV[1].a for VV in Vchoices])==tuple(V[1].a)).all(axis=1))[0] for V in Vchoices]
-        # evaluate index of phase-functions that have equal a parameter
-        equal_a = list({tuple(row) for row in equals})
-
-        # initialize a combined phase-function class element
-        Vcomb = Phasefunction(tau=0.7, omega=0.3)
-        Vcomb.ncoefs = max([V[1].ncoefs for V in Vchoices])     # set ncoefs of the combined volume-class element to the maximum
-                                                                #   number of coefficients within the chosen functions.
-                                                                #   (this is necessary for correct evaluation of fn-coefficients)
-
-        # evaluation of combined expansion in legendre-polynomials
-        dummylegexpansion = []
-        for i in range(0,len(equal_a)):
-
-            Vdummy = Phasefunction(tau=0.7, omega=0.3)
-            Vequal = np.take(Vchoices,equal_a[i],axis=0)        # select V choices where a parameter is equal
-
-            Vdummy.ncoefs = max([V[1].ncoefs for V in Vequal])  # set ncoefs to the maximum number within the choices with equal a-parameter
-
-            for V in Vequal:                                    # loop over phase-functions with equal a-parameter
-
-                # set parameters based on chosen phase-functions and evaluate combined legendre-expansion
-                Vdummy.a = V[1].a
-                Vdummy.tau = V[1].tau
-                Vdummy.omega = V[1].omega
-                Vdummy._func = Vdummy._func + V[1]._func * V[0]
-                Vdummy.legcoefs = Vdummy.legcoefs + V[1].legcoefs * V[0]
-
-            dummylegexpansion = dummylegexpansion + [Vdummy.legexpansion]
-
-        # combine legendre-expansions for each a-parameter based on given combined legendre-coefficients
-        Vcomb.legexpansion = lambda mu_0,mu_ex,p_0,p_ex,geometry : np.sum([lexp(mu_0,mu_ex,p_0,p_ex,geometry) for lexp in dummylegexpansion])
-
-
-        for V in Vchoices:
-            # set parameters based on chosen classes to define analytic function representation
-            Vcomb.tau = V[1].tau
-            Vcomb.omega = V[1].omega
-            Vcomb._func = Vcomb._func + V[1]._func * V[0]
-
-        return Vcomb
 
 
 

--- a/rt1/rt1.py
+++ b/rt1/rt1.py
@@ -83,14 +83,25 @@ class RT1(object):
 
         assert RV is not None, 'ERROR: needs to provide volume information'
 
+        # the asserts for omega & tau are performed inside the RT1-class rather than the Volume-class
+        # to allow calling Volume-elements without providing omega & tau which is needed to generate
+        # linear-combinations of Volume-elements with unambiguous tau- & omega-specifications
         # if an array is provided for RV, call Vcombiner function to generate a combined phase-function element
         if isinstance(RV,(list,np.ndarray)):
             self.RV = self._Vcombiner(RV)
         else:
             self.RV = RV
 
+        assert self.RV.omega is not None, 'Single scattering albedo needs to be provided'
+        assert self.RV.tau is not None, 'Optical depth needs to be provided'
 
+        assert self.RV.omega >= 0.
+        assert self.RV.omega <= 1.
+        assert self.RV.tau >= 0.
         assert SRF is not None, 'ERROR: needs to provide surface information'
+
+        if self.RV.tau == 0.:
+            assert self.RV.omega == 0., 'ERROR: If optical depth is equal to zero, then OMEGA can not be larger than zero'
 
         # if an array is provided for SRF, call SRFcombiner function to generate a combined BRDF-function element
         if isinstance(SRF,(list,np.ndarray)):

--- a/rt1/volume.py
+++ b/rt1/volume.py
@@ -102,15 +102,35 @@ class Volume(Scatter):
         return sp.Sum(self.legcoefs*sp.legendre(n,self.scat_angle(sp.pi-theta_i,theta_s,phi_i,phi_s, self.a)),(n,0,NP-1))  #.doit()  # this generates a code still that is not yet evaluated; doit() will result in GMMA error due to potential negative numbers
 
 
-class Phasefunction(Volume):
-        """
-        dummy-Volume-class object used to generate linear-combinations of volume-phase-functions
-        """
-        def __init__(self, **kwargs):
-            super(Phasefunction, self).__init__(**kwargs)
-            self._set_function()
-            self._set_legcoefficients()
 
+
+class LinCombV(Volume):
+        '''
+        Class to generate linear-combinations of volume-class elements
+        '''
+        def __init__(self, Vchoices=None, **kwargs):
+            '''
+            Parameters
+            ----------
+
+            tau : float
+                optical depth of the combined phase-function
+                ATTENTION: tau-values provided within the Vchoices-list will not be considered!
+            omega : float
+                single scattering albedo of the combined phase-function
+                ATTENTION: omega-values provided within the Vchoices-list will not be considered!
+
+            Vchoices : [ [float, Volume]  ,  [float, Volume]  ,  ...]
+                     a list that contains the the individual phase-functions (Volume-objects)
+                     and the associated weighting-factors (floats) of the linear-combination.
+                     ATTENTION: since the normalization of the phase-function is fixed, the weighting-factors must equate to 1 !
+
+            '''
+            super(LinCombV, self).__init__(**kwargs)
+
+            self.Vchoices = Vchoices
+            self._set_function()
+            self._set_legexpansion()
 
         def _set_function(self):
             """
@@ -120,16 +140,109 @@ class Phasefunction(Volume):
             theta_s = sp.Symbol('theta_s')
             phi_i = sp.Symbol('phi_i')
             phi_s = sp.Symbol('phi_s')
-            self._func = 0.
+            self._func = self._Vcombiner()._func
 
-        def _set_legcoefficients(self):
-            """
-            set Legrende coefficients
-            needs to be a function that can be later evaluated by subsituting 'n'
-            """
+        def _set_legexpansion(self):
+            '''
+            set legexpansion to the combined legexpansion
+            '''
+            self.ncoefs = self._Vcombiner().ncoefs
+            self.legexpansion = self._Vcombiner().legexpansion
 
-            n = sp.Symbol('n')
-            self.legcoefs = 0.
+
+        def _Vcombiner(self):
+            '''
+            Returns a Volume-class element based on an input-array of Volume-class elements.
+            The array must be shaped in the form:
+                Vchoices = [  [ weighting-factor   ,   Volume-class element ]  ,  [ weighting-factor   ,   Volume-class element ]  , .....]
+
+            In order to keep the normalization of the phase-functions correct,
+            the sum of the weighting factors must equate to 1!
+
+
+            ATTENTION: the .legexpansion()-function of the combined volume-class element is no longer related to its legcoefs (which are set to 0.)
+                       since the individual legexpansions of the combined volume-class elements are possibly evaluated with a different a-parameter
+                       of the generalized scattering angle! This does not affect any calculations, since the evaluation is exclusively based on the
+                       use of the .legexpansion()-function.
+
+            '''
+
+            class Phasefunction(Volume):
+                """
+                dummy-Volume-class object used to generate linear-combinations of volume-phase-functions
+                """
+                def __init__(self, **kwargs):
+                    super(Phasefunction, self).__init__(**kwargs)
+                    self._set_function()
+                    self._set_legcoefficients()
+
+
+                def _set_function(self):
+                    """
+                    define phase function as sympy object for later evaluation
+                    """
+                    theta_i = sp.Symbol('theta_i')
+                    theta_s = sp.Symbol('theta_s')
+                    phi_i = sp.Symbol('phi_i')
+                    phi_s = sp.Symbol('phi_s')
+                    self._func = 0.
+
+                def _set_legcoefficients(self):
+                    """
+                    set Legrende coefficients
+                    needs to be a function that can be later evaluated by subsituting 'n'
+                    """
+
+                    n = sp.Symbol('n')
+                    self.legcoefs = 0.
+
+
+            # test if the weighting-factors equate to 1.
+            np.testing.assert_almost_equal(desired = 1.,actual = np.sum([V[0] for V in self.Vchoices]), verbose = False, err_msg='The sum of the phase-function weighting-factors must equate to 1 !'),
+
+            # find phase functions with equal a parameters
+            equals = [np.where((np.array([VV[1].a for VV in self.Vchoices])==tuple(V[1].a)).all(axis=1))[0] for V in self.Vchoices]
+            # evaluate index of phase-functions that have equal a parameter
+            equal_a = list({tuple(row) for row in equals})
+
+            # initialize a combined phase-function class element
+            Vcomb = Phasefunction(tau=self.tau, omega=self.omega)           # set tau and omega to the values for the combined phase-function
+            Vcomb.ncoefs = max([V[1].ncoefs for V in self.Vchoices])        # set ncoefs of the combined volume-class element to the maximum
+                                                                            #   number of coefficients within the chosen functions.
+                                                                            #   (this is necessary for correct evaluation of fn-coefficients)
+
+            # evaluation of combined expansion in legendre-polynomials
+            dummylegexpansion = []
+            for i in range(0,len(equal_a)):
+
+                Vdummy = Phasefunction()
+                Vequal = np.take(self.Vchoices,equal_a[i],axis=0)       # select V choices where a parameter is equal
+
+                Vdummy.ncoefs = max([V[1].ncoefs for V in Vequal])      # set ncoefs to the maximum number within the choices with equal a-parameter
+
+                for V in Vequal:                                        # loop over phase-functions with equal a-parameter
+
+                    # set parameters based on chosen phase-functions and evaluate combined legendre-expansion
+                    Vdummy.a = V[1].a
+                    Vdummy._func = Vdummy._func + V[1]._func * V[0]
+                    Vdummy.legcoefs = Vdummy.legcoefs + V[1].legcoefs * V[0]
+
+                dummylegexpansion = dummylegexpansion + [Vdummy.legexpansion]
+
+            # combine legendre-expansions for each a-parameter based on given combined legendre-coefficients
+            Vcomb.legexpansion = lambda mu_0,mu_ex,p_0,p_ex,geometry : np.sum([lexp(mu_0,mu_ex,p_0,p_ex,geometry) for lexp in dummylegexpansion])
+
+
+            for V in self.Vchoices:
+                # set parameters based on chosen classes to define analytic function representation
+                Vcomb._func = Vcomb._func + V[1]._func * V[0]
+
+            return Vcomb
+
+
+
+
+
 
 
 

--- a/rt1/volume.py
+++ b/rt1/volume.py
@@ -9,18 +9,7 @@ import sympy as sp
 class Volume(Scatter):
     def __init__(self, **kwargs):
         self.omega = kwargs.pop('omega', None)
-        assert self.omega is not None, 'Single scattering albedo needs to be provided'
-
         self.tau = kwargs.pop('tau', None)
-        assert self.tau is not None, 'Optical depth needs to be provided'
-
-        assert self.omega >= 0.
-        assert self.omega <= 1.
-        assert self.tau >= 0.
-
-        if self.tau == 0.:
-            assert self.omega == 0., 'ERROR: If optical depth is equal to zero, then OMEGA can not be larger than zero'
-        
      
         # set scattering angle generalization-matrix to [-1,1,1] if it is not explicitly provided by the chosen class
         # this results in a peak in forward-direction which is suitable for describing volume-scattering phase-functions


### PR DESCRIPTION
- the test if omega & tau are provided has been moved to the RT1-class 
        - to call Volume-elements without omega/tau when defining a linear-combination
- new classes **LinCombV** and **LinCombSRF** have been introduced that are now
 used to generate linear-combinations