### PR TITLE
fixed autodoc specifications to work on readthedocs

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -48,12 +48,8 @@ help:
 
 clean:
 	rm -rf $(BUILDDIR)/*
-	rm -rf autodoc
 
-autodoc:
-	sphinx-apidoc -f -o autodoc ../rt1
-
-html: autodoc
+html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."

--- a/doc/annex_technical.rst
+++ b/doc/annex_technical.rst
@@ -1,7 +1,37 @@
 Technical documentation
 =======================
 
-.. toctree::
-   :maxdepth: 4
+RT1-module
+------------
+.. automodule:: rt1.rt1
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-   autodoc/rt1
+RTplots-module
+---------------
+.. automodule:: rt1.rtplots
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Scatter-module
+---------------
+.. automodule:: rt1.scatter
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Surface-module
+---------------
+.. automodule:: rt1.surface
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Volume-module
+--------------
+.. automodule:: rt1.volume
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -28,10 +28,16 @@ def setup(app):
     app.add_stylesheet('my_theme.css')
 
 
+import mock
+MOCK_MODULES = ['numpy', 'scipy', 'scipy.special', 'sympy', 'symengine', 'matplotlib', 'matplotlib.pyplot', 'matplotlib.lines', 'mpl_toolkits', 'mpl_toolkits.mplot3d']
+for mod_name in MOCK_MODULES:
+	sys.modules[mod_name] = mock.Mock()
+
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.insert(0, os.path.abspath('.')+os.sep+'..')
+sys.path.insert(0, os.path.abspath('..')+os.sep)
 
 # -- General configuration ------------------------------------------------
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -14,6 +14,7 @@
 
 import sys
 import os
+import mock
 
 
 # Enable figure-numbering in "latex-style" (i.e. autonumbering with Fig.1, Fig.2 etc.)
@@ -28,10 +29,9 @@ def setup(app):
     app.add_stylesheet('my_theme.css')
 
 
-import mock
 MOCK_MODULES = ['numpy', 'scipy', 'scipy.special', 'sympy', 'symengine', 'matplotlib', 'matplotlib.pyplot', 'matplotlib.lines', 'mpl_toolkits', 'mpl_toolkits.mplot3d']
 for mod_name in MOCK_MODULES:
-	sys.modules[mod_name] = mock.Mock()
+    sys.modules[mod_name] = mock.Mock()
 
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -37,7 +37,7 @@ for mod_name in MOCK_MODULES:
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.insert(0, os.path.abspath('..')+os.sep)
+sys.path.insert(0, os.path.abspath('..') + os.sep)
 
 # -- General configuration ------------------------------------------------
 


### PR DESCRIPTION
I changed the way of how autodoc is implemented... now it's working on readthedocs too!

- it seems that assigning autodoc in the Makefile as sphinx-extension
    is enough to create the documentation... (no need of explicitly calling it)

- used mock-module to load non-standard modules to ensure that readthedocs can import our module